### PR TITLE
Hashmap parsing security and misc improvements

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -48,7 +48,7 @@ class Ninny(val crossScalaVersion: String)
 
   def ivyDeps =
     Agg(
-      ivy"org.typelevel::jawn-parser:1.0.0",
+      ivy"org.typelevel::jawn-parser:1.3.0",
       ivy"com.chuusai::shapeless:2.3.3",
       ivy"org.scala-lang.modules::scala-collection-compat:2.4.1",
       ivy"com.typesafe.scala-logging::scala-logging:3.9.4"
@@ -118,7 +118,9 @@ object ubjson extends ScalaModule with PublishMod {
 }
 
 object `script-kit` extends mill.Cross[ScriptKit](`2.12`, `2.13`)
-class ScriptKit(val crossScalaVersion: String) extends CrossScalaModule with PublishMod {
+class ScriptKit(val crossScalaVersion: String)
+    extends CrossScalaModule
+    with PublishMod {
 
   def artifactName = "ninny-script-kit"
 
@@ -126,6 +128,6 @@ class ScriptKit(val crossScalaVersion: String) extends CrossScalaModule with Pub
 
   object test extends Tests {
     def testFrameworks = Seq("org.scalatest.tools.Framework")
-    def ivyDeps = Agg(ivy"org.scalatest::scalatest:3.2.0")
+    def ivyDeps        = Agg(ivy"org.scalatest::scalatest:3.2.0")
   }
 }

--- a/ninny/src/io/github/kag0/ninny/FromJsonInstances.scala
+++ b/ninny/src/io/github/kag0/ninny/FromJsonInstances.scala
@@ -20,7 +20,13 @@ trait FromJsonInstances extends LowPriorityFromJsonInstances with LazyLogging {
 
   implicit val booleanFromJson: FromJson[Boolean] = FromJson.fromSome {
     case JsonBoolean(value) => Success(value)
-    case json               => Failure(new JsonException(s"Expected boolean, got $json"))
+    case JsonString(value) =>
+      try { Success(value.toBoolean) }
+      catch {
+        case e: IllegalArgumentException =>
+          Failure(new JsonException(e.getMessage, e))
+      }
+    case json => Failure(new JsonException(s"Expected boolean, got $json"))
   }
 
   implicit val nullFromJson: FromJson[Null] = FromJson.fromSome {
@@ -30,6 +36,7 @@ trait FromJsonInstances extends LowPriorityFromJsonInstances with LazyLogging {
 
   implicit val doubleFromJson: FromJson[Double] = FromJson.fromSome {
     case JsonNumber(value) => Success(value)
+    case JsonString(value) => Json.parse(value).flatMap(_.to[Double])
     case json              => Failure(new JsonException(s"Expected number, got $json"))
   }
 

--- a/ninny/src/io/github/kag0/ninny/Json.scala
+++ b/ninny/src/io/github/kag0/ninny/Json.scala
@@ -3,12 +3,18 @@ package io.github.kag0.ninny
 import io.github.kag0.ninny.ast.JsonValue
 import org.typelevel.jawn.Parser
 import io.github.kag0.ninny.jawn._
+import scala.collection.compat.immutable.ArraySeq
 
 object Json {
   def parse(s: String, highPrecision: Boolean = false) = {
     implicit def facade = if (highPrecision) DecimalFacade else DoubleFacade
     Parser.parseFromString(s)
   }
-  
+
+  def parseArray(s: ArraySeq[Byte], highPrecision: Boolean = false) = {
+    implicit def facade = if (highPrecision) DecimalFacade else DoubleFacade
+    Parser.parseFromByteArray(s.unsafeArray.asInstanceOf[Array[Byte]])
+  }
+
   def render(json: JsonValue) = json.toString
 }

--- a/ninny/src/io/github/kag0/ninny/ast/package.scala
+++ b/ninny/src/io/github/kag0/ninny/ast/package.scala
@@ -32,9 +32,11 @@ package object ast {
       this match {
         case JsonNull           => "null"
         case JsonBoolean(value) => value.toString
-        case JsonNumber(value)  => value.toString.stripSuffix(".0")
-        case s: JsonString      => s.toString
-        case JsonArray(values)  => values.mkString("[", ",", "]")
+        case JsonDouble(value)  => value.toString.stripSuffix(".0")
+        case JsonDecimal(preciseValue) =>
+          preciseValue.toString.stripSuffix(".0")
+        case s: JsonString     => s.toString
+        case JsonArray(values) => values.mkString("[", ",", "]")
 
         case JsonBlob(value) =>
           val array = value.unsafeArray.asInstanceOf[Array[Byte]]

--- a/ninny/test/src/io/github/kag0/ninny/JsonSpec.scala
+++ b/ninny/test/src/io/github/kag0/ninny/JsonSpec.scala
@@ -547,14 +547,12 @@ class JsonSpec
   }
 
   it should "parse decimal strings and numbers" in {
-    val big = BigDecimal(Double.MaxValue) + BigDecimal("12.3")
-    val parsedString =
-      Json.parse('"' + big.toString + '"', true).to[BigDecimal].success.value
-    val parsedNumber =
-      Json.parse(s"${big.toString}", true).to[BigDecimal].success.value
+    val big          = BigDecimal(Double.MaxValue) + BigDecimal("12.3")
+    val parsedString = Json.parse('"' + big.toString + '"', true)
+    val parsedNumber = Json.parse(s"${big.toString}", true)
 
-    parsedNumber shouldEqual big
-    parsedString shouldEqual big
+    parsedNumber.to[BigDecimal].success.value shouldEqual big
+    parsedString.to[BigDecimal].success.value shouldEqual big
   }
 
   it should "parse integer strings and numbers" in {
@@ -597,6 +595,9 @@ class JsonSpec
     val d = BigDecimal("123.456")
     i.toSomeJson shouldEqual JsonDecimal(BigDecimal(123))
     d.toSomeJson shouldEqual JsonDecimal(d)
+    Json.render(
+      (BigDecimal(Double.MaxValue) + Double.MaxValue).toSomeJson
+    ) shouldEqual "3.5953862697246314E+308"
   }
 
   "JsonBlob" should "encode and decode to base64" in {

--- a/ubjson/test/src/io/github/kag0/ninny/binary/UbJsonSpec.scala
+++ b/ubjson/test/src/io/github/kag0/ninny/binary/UbJsonSpec.scala
@@ -267,8 +267,12 @@ class UbJsonSpec extends AnyFlatSpec with should.Matchers with TryValues {
       ArraySeq[Byte]('H', 'i', 10, '1', '2', '3', '4', '5', '.', '6', '7', '8',
         '9')
 
-    UbJson.render(JsonDecimal(BigDecimal("3.7e-5"))) shouldEqual
-      ArraySeq[Byte]('H', 'i', 6, '3', '.', '7', 'E', '-', '5')
+    UbJson.render(JsonDecimal(BigDecimal("3.7e-10"))) shouldEqual
+      ArraySeq[Byte]('H', 'i', 7, '3', '.', '7', 'E', '-', '1', '0')
+
+    UbJson.render(JsonDecimal(BigDecimal(Double.MaxValue))) shouldEqual
+      ArraySeq[Byte]('H', 'i', 23, '1', '.', '7', '9', '7', '6', '9', '3', '1',
+        '3', '4', '8', '6', '2', '3', '1', '5', '7', 'E', '+', '3', '0', '8')
   }
 
   val stringBin            = ArraySeq[Byte]('S', 'i', 3) :++ "foo".getBytes


### PR DESCRIPTION
Default immutable map (hash trie) was vulnerable to DoS attacks, switched to `TreeMap` for parsing. There are still some sharp edges, read https://github.com/scala/bug/issues/11203
